### PR TITLE
Fixed "vaule" typo on line 81

### DIFF
--- a/src/politespace.js
+++ b/src/politespace.js
@@ -78,7 +78,7 @@
 	};
 
 	Politespace.prototype.reset = function() {
-		this.element.value = this.unformat( this.element.vaule );
+		this.element.value = this.unformat( this.element.value );
 	};
 
 	w.Politespace = Politespace;


### PR DESCRIPTION
Not sure if `this.element.vaule` was intentional, so I switched to `value`, as that's referenced throughout the script.
