### PR TITLE
allow regexp to be set from data attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 temp/
 bower_components/
 dist/
+*.swp

--- a/src/politespace.js
+++ b/src/politespace.js
@@ -11,9 +11,23 @@
 			return;
 		}
 
-		var groupRegMatch;
+		var groupRegMatch, allowMatch;
 
 		this.element = element;
+
+		allowMatch = this.element.getAttribute("data-allowmatch");
+		if ( allowMatch && allowMatch !== "" ) {
+			try {
+				allowMatch = new RegExp(allowMatch, "g");
+			}
+			catch (e) {
+				allowMatch = false;
+			}
+		}
+		else {
+			allowMatch = false;
+		}
+		this.allowMatch = allowMatch || /\D/g;
 
 		this.groupLength = this.element.getAttribute( "data-grouplength" ) || 3;
 		groupRegMatch = this._buildRegexArr( this.groupLength );
@@ -34,8 +48,9 @@
 	};
 
 	Politespace.prototype.format = function( value ) {
-		var val = value.replace( /\D/g, '' ),
-			match;
+		var val, match;
+
+		val = value.replace( this.allowMatch, '' );
 
 		if( this.groupRegNonUniform ) {
 			match = val.match( this.groupReg );


### PR DESCRIPTION
> I'm not submitting this as something that could be merged in this current state. It's just an idea. I'm only functional in JavaScript at the level I need to be in order to use jQuery for DOM manipulation. 

I wanted the ability to use this plugin for more than digits. It's possible to put a data attribute string on the element and pass that into the RegExp constructor. You have to tweak it a bit but it's easy to test from the JavaScript console using `new RegExp("\\W", "g")`. In this PR I'm using the `\g` atom because it's probably okay to make it the only one supported for the argument.

If anyone wants to advise me on how to improve it to the point that it could be merged I'd be glad to update it.