### PR TITLE
Make package exportable on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"type": "git",
 		"url": "git://github.com/filamentgroup/politespace.git"
 	},
+  "main": "./src/politespace.js",
 	"scripts": {
 		"test": "grunt test"
 	},


### PR DESCRIPTION
In order to require the module like so:

```
var politespace = require('pollitespace');
```

there needs to be a `"main"` property in the package.json. We had to
come up with a workaround here:

https://github.com/18F/web-design-standards/commit/74a8a5787a954c66a827581968b7a4688218c76c
