### PR TITLE
handle paste and fix input

### DIFF
--- a/src/politespace-init.js
+++ b/src/politespace-init.js
@@ -30,6 +30,33 @@
 					polite.update();
 					polite.updateProxy();
 				})
+				.bind( "paste", function(e){
+					var event = e.originalEvent || e;
+
+					// http://stackoverflow.com/questions/6035071/intercept-paste-event-in-javascript
+					var pastedText;
+
+					if (window.clipboardData && window.clipboardData.getData) { // IE
+						pastedText = window.clipboardData.getData('Text');
+					} else if (event.clipboardData && event.clipboardData.getData) {
+						pastedText = event.clipboardData.getData('text/plain');
+					}
+
+					// if we were unable to get the pasted text avoid doing anything
+					if( !pastedText ){
+						return;
+					}
+
+					// otherwise force the text to look right
+					this.value = polite.conform(pastedText);
+
+					// prevent the original paste behavior
+					event.preventDefault();
+
+					// and update the state of the plugin
+					polite.update();
+					polite.updateProxy();
+				})
 				.bind( "input keydown", function() {
 					$( this ).trigger( "politespace-input" );
 

--- a/src/politespace.js
+++ b/src/politespace.js
@@ -167,6 +167,18 @@
 		this.$element.attr( "data-grouplength", length );
 	};
 
+	// TODO likely needs more conform checks for other input types and configs
+	// they can be added as needed here
+	Politespace.prototype.conform = function( text ) {
+		var fixed = text;
+
+		if( this.$element.attr("type") === "number" ){
+			fixed = fixed.replace(/[^0-9]/g, "");
+		}
+
+		return fixed;
+	};
+
 	w.Politespace = Politespace;
 
 }( this, jQuery ));


### PR DESCRIPTION
This currently works to clean up numeric inputs on paste to make sure that paste works properly in Safari. There are no tests yet, so this is primarily for discussion.

Firefox does us the great service of actually changing the content?

![demo](https://cloud.githubusercontent.com/assets/23505/15803653/cd3480cc-2a9e-11e6-948b-2b2d39ccc761.gif)

This bug is also present on master but is noted here because it overlaps with testing for this paste binding.




