### PR TITLE
[WIP] Remove jQuery dependency

### DIFF
--- a/src/politespace-test.js
+++ b/src/politespace-test.js
@@ -3,8 +3,8 @@
 
 	function insertHtml( html ) {
 		var $fixture = $( "#qunit-fixture" );
-			$fixture.html( html );
-			$fixture.trigger( "enhance" );
+		$fixture.html( html );
+		$fixture.trigger( "enhance" );
 	}
 
 	QUnit.module( "Defaults", {
@@ -224,8 +224,9 @@
 	});
 
 	QUnit.test( "Test ancestor class names", function( assert ) {
-		assert.equal( this.pspace.$element.parent().is( ".field" ), true, "First ancestor is the proxy anchor (.field)." );
-		assert.equal( this.pspace.$element.parent().parent().is( ".politespace-proxy" ), true, "Second ancestor is the politespace proxy" );
+		var parent = this.pspace.element.parentNode;
+		assert.equal( parent.classList.contains( "field" ), true, "First ancestor is the proxy anchor (.field)." );
+		assert.equal( parent.parentNode.classList.contains( "politespace-proxy" ), true, "Second ancestor is the politespace proxy" );
 	});
 
 }( this, jQuery ));

--- a/src/politespace.js
+++ b/src/politespace.js
@@ -15,7 +15,7 @@
 		this.delimiter = element.getAttribute( "data-delimiter" ) || " ";
 		// https://en.wikipedia.org/wiki/Decimal_mark
 		this.decimalMark = element.getAttribute( "data-decimal-mark" ) || "";
-		this.reverse = element.matches( "[data-reverse]" );
+		this.reverse = element.hasAttribute( "data-reverse" );
 		this.strip = element.getAttribute( "data-politespace-strip" );
 		this.groupLength = element.getAttribute( "data-grouplength" ) || 3;
 
@@ -153,17 +153,19 @@
 		}
 
 		var computed = window.getComputedStyle( this.element );
+
 		var el = document.createElement( "div" );
 		el.className = "politespace-proxy active";
+
 		var nextSibling = this.proxyAnchor.nextSibling;
 		var parent = this.proxyAnchor.parentNode;
 
 		var proxy = document.createElement( "div" );
 		proxy.className = "politespace-proxy-val";
 		proxy.style.setProperty( "font", computed.getPropertyValue( "font" ) );
-		proxy.style.setProperty( "padding-left", sumStyles( this.element, [ "padding-left", "border-left-width" ] ) + "px");
-		proxy.style.setProperty( "padding-right", sumStyles( this.element, [ "padding-right", "border-right-width" ] ) + "px");
-		proxy.style.setProperty( "top",  sumStyles( this.element, [ "padding-top", "border-top-width", "margin-top" ] ) + "px");
+		proxy.style.setProperty( "padding-left", sumStyles( computed, [ "padding-left", "border-left-width" ] ) + "px");
+		proxy.style.setProperty( "padding-right", sumStyles( computed, [ "padding-right", "border-right-width" ] ) + "px");
+		proxy.style.setProperty( "top",  sumStyles( computed, [ "padding-top", "border-top-width", "margin-top" ] ) + "px");
 		this.proxy = el.appendChild( proxy );
 		el.appendChild( this.proxyAnchor );
 


### PR DESCRIPTION
This is a first stab at removing the jQuery dependency from the Politespace "core" class defined in `src/politespace.js`. This would eventually fix #13, and _in theory_ wouldn't affect the jQuery implementation of the other types.

**Some of the tests fail, so this definitely isn't ready for prime time yet.** But if there's interest in this, I can move forward and see about getting them fixed. Also, there are some caveats regarding browser compatibility:
- [Support](http://caniuse.com/#feat=matchesselector) for [Element#matches(selector)](https://developer.mozilla.org/en-US/docs/Web/API/Element/matches) is lagging in IE and Edge, where it would need to be prefixed.
- [Support](http://caniuse.com/#feat=element-closest) for [Element#closest(selector)](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest) is missing entirely in IE and Edge.

The [closest polyfill](https://github.com/jonathantneal/closest) handles shimming for both of the DOM methods above, and is tiny compared to jQuery.
